### PR TITLE
Fix GH Pages deploy and add CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install, build, and validate site
+        uses: withastro/action@v5
+        with:
+          path: .
+          node-version: 22
+          package-manager: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: withastro/action@v5
         with:
           path: .
-          node-version: 20
+          node-version: 22
           package-manager: npm
 
   deploy:


### PR DESCRIPTION
The Astro 5 to 6 major version bump (dependabot PR #28) requires
Node.js 22+, but deploy.yml specified node-version: 20. Update to
Node 22 to fix the deployment.

Also add a CI workflow that builds the site on pull requests so that
breaking changes like this are caught before merging.

https://claude.ai/code/session_01A8xLxs5TPS9rFQa6r8n3Vp