### PR TITLE
Add dependency version pinning lint

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-caret-version-dependencies": "error",
+    "no-tilde-version-dependencies": "error",
+    "no-wildcard-version-dependencies": "error",
+    "no-caret-version-devDependencies": "error",
+    "no-tilde-version-devDependencies": "error",
+    "no-wildcard-version-devDependencies": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint:pkg": "npmpackagejsonlint package.json"
   },
   "dependencies": {
     "astro": "^6.0.8"
+  },
+  "devDependencies": {
+    "npmpackagejsonlint": "3.7.1"
   },
   "private": true
 }


### PR DESCRIPTION
Adds npm-package-json-lint with rules that error on `^`, `~`, and wildcard version specs in dependencies and devDependencies. Adds a `lint:pkg` script.